### PR TITLE
Allow input of colorized text to title, header and body cells

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         ruby-version: [3.0, 3.4]
     runs-on: ${{ matrix.os }}-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: taiki-e/install-action@just
       - uses: ruby/setup-ruby@v1
         with:

--- a/lib/table_tennis/stage/render.rb
+++ b/lib/table_tennis/stage/render.rb
@@ -50,7 +50,7 @@ module TableTennis
         title_width = data.table_width - 4
         title = Util::Strings.truncate(config.title, title_width)
         title_style = data.get_style(r: :title) || :cell
-        line = paint(title.center(title_width), title_style || :cell)
+        line = paint(ansi_center(title, title_width), title_style || :cell)
         paint("#{pipe} #{line} #{pipe}", Theme::BG)
       end
 
@@ -71,7 +71,8 @@ module TableTennis
 
       def render_cell(value, r, c, default_cell_style)
         # calculate whitespace based on plaintext
-        whitespace = columns[c].width - Util::Strings.width(value)
+        whitespace = columns[c].width -
+          Util::Strings.width(Util::Strings.unpaint(value))
 
         # cell > column > default > cell (row styles are applied elsewhere)
         style = nil
@@ -143,6 +144,18 @@ module TableTennis
         # delegate painting to the theme, if color is enabled
         str = theme.paint(str, style) if config.color
         str
+      end
+
+      # center string, accounting for ansi codes
+      def ansi_center(str, width)
+        unpainted_str = Util::Strings.unpaint(str)
+        return str if unpainted_str.length >= width
+
+        padding = width - unpainted_str.length
+        left_padding = padding / 2
+        right_padding = padding - left_padding
+
+        (" " * left_padding) + str + (" " * right_padding)
       end
 
       def pipe = paint(PIPE, :chrome)

--- a/lib/table_tennis/util/strings.rb
+++ b/lib/table_tennis/util/strings.rb
@@ -33,13 +33,19 @@ module TableTennis
       # truncate a string based on the display width of the grapheme clusters.
       # Should handle emojis and international characters
       def truncate(text, stop)
-        if simple?(text)
-          return (text.length > stop) ? "#{text[0, stop - 1]}…" : text
+        # handle ansi codes by working with unpainted version
+        work_text = text.match?(/\e\[\d*m/) ? unpaint(text) : text
+
+        if simple?(work_text)
+          truncated = (work_text.length > stop) ?
+            "#{work_text[0, stop - 1]}…" :
+            work_text
+          return close_ansi_if_needed(truncated, text)
         end
 
         # get grapheme clusters, and attach zero width graphemes to the previous grapheme
         list = [].tap do |accum|
-          text.grapheme_clusters.each do
+          work_text.grapheme_clusters.each do
             if width(_1) == 0 && !accum.empty?
               accum[-1] = "#{accum[-1]}#{_1}"
             else
@@ -54,13 +60,30 @@ module TableTennis
           next if (width += w) <= stop
 
           # we've gone too far. do we need to pop for the ellipsis?
-          text = list[0, _1]
-          text.pop if width - w == stop
-          return "#{text.join}…"
+          text_parts = list[0, _1]
+          text_parts.pop if width - w == stop
+          return close_ansi_if_needed("#{text_parts.join}…", text)
         end
 
-        text
+        # if we get here, the text fits
+        close_ansi_if_needed(work_text, text)
       end
+
+      # helper to close ansi codes if needed
+      def close_ansi_if_needed(truncated, original)
+        return truncated unless original.match?(/\e\[\d*m/)
+
+        # extract opening ANSI codes from the beginning of the original string
+        opening_codes = original.scan(/^\e\[[1-9]\d*m/).join
+
+        # if we have opening codes, wrap the truncated text with them
+        if !opening_codes.empty?
+          "#{opening_codes}#{truncated}\e[0m"
+        else
+          truncated
+        end
+      end
+      private_class_method :close_ansi_if_needed
 
       SIMPLE = /\A[\x00-\x7F–—…·‘’“”•áéíñóúÓ]*\Z/
 

--- a/test/util/test_strings.rb
+++ b/test/util/test_strings.rb
@@ -73,6 +73,41 @@ module TableTennis
         (4..6).each { assert_equal "👋🏻👋🏿", Strings.truncate(hands, _1), "with #{_1}" }
       end
 
+      def test_ansi_truncate
+        # test that ANSI codes are properly closed when truncated
+        colored_text = Paint["hello world", :red]
+
+        # when truncated in the middle, preserve and close color
+        result = Strings.truncate(colored_text, 7)
+        assert_equal "\e[31mhello …\e[0m", result
+
+        # when not truncated, should preserve original
+        result = Strings.truncate(colored_text, 15)
+        assert_equal colored_text, result
+
+        # test with unclosed ANSI code
+        unclosed_text = "\e[31mhello world"
+        result = Strings.truncate(unclosed_text, 7)
+        assert_equal "\e[31mhello …\e[0m", result
+
+        # test with emojis and color:
+        # rocket=2, pepper=1, h=1, ellipsis=1 = 5 total
+        emoji_colored_text = Paint["🚀🌶hello", :blue]
+        result = Strings.truncate(emoji_colored_text, 5)
+        assert_equal "\e[34m🚀🌶h…\e[0m", result
+
+        # test shorter truncation:
+        # rocket=2, pepper=1, ellipsis=1 = 4 total
+        result = Strings.truncate(emoji_colored_text, 4)
+        assert_equal "\e[34m🚀🌶…\e[0m", result
+
+        # test longer emoji text with color:
+        # rocket=2, pepper=1, party=2, h=1, ellipsis=1 = 7 total
+        long_emoji_text = Paint["🚀🌶🎉hello world", :green]
+        result = Strings.truncate(long_emoji_text, 7)
+        assert_equal "\e[32m🚀🌶🎉h…\e[0m", result
+      end
+
       def test_titleize
         [
           ["action", "Action"],


### PR DESCRIPTION
Fixes #12.

1. Content input that is already colorized with ANSI color codes cause premature padding truncation, as the original character width calculations included the ANSI escape codes as part of "visible character length".

2. A colorized title required more handling. Title positioning uses `String#center` to format the title row, which required a new ANSI-escape-code-aware implementation of centering. This is implemented in a new method `ansi_center` that is color aware.

3. Truncation is another impacted area where colorized text when the width is incorrectly calculated, will cause premature truncation of the display string. The `truncate` method was updated to be color-aware, and can now automatically close colorized strings that were "truncated in the middle".

4. Two corresponding tests have been added:
  * Testing rendering of a table with a colorized title, a colorized header cell and a colorized body cell.
  * Testing truncation of colorized text, with emojis.

Hope this is useful!

FYI @gurgeous 

Note: This is a contribution from the LutaML project (@lutaml) at Ribose (@riboseinc)