### PR TITLE
ansicells (fixes #12, fixes #13)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         ruby-version: [3.0, 3.4]
     runs-on: ${{ matrix.os }}-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: taiki-e/install-action@just
       - uses: ruby/setup-ruby@v1
         with:

--- a/README.md
+++ b/README.md
@@ -69,32 +69,32 @@ options = {
 
 #### Popular Options
 
-| option | default | details |
-| ------ | ------- | ------- |
-| `color_scales` | ─ | Color code a column of floats, similar to the "conditional formatting" feature in Google Sheets. See [docs below](#color-scales). |
-| `columns` | ─ | Manually set which columns to include. Leave unset to show all columns.
-| `headers` | ─ | Specify some or all column headers. For example, `{user_id: "Customer"}`. When unset, headers are inferred. |
-| `mark` | ─ | `mark` is a way to highlight specific columns with a nice color. For example, use `mark: ->(row) { row[:planet] == "tatooine" }` to highlight those rows. Your lambda can also return a specific bg color or Paint color array.
-| `row_numbers` | `false` | Show row numbers in the table. |
-| `search` | ─ | String/regex to highlight in output. |
-| `separators` | `true` | Include column and header separators in output. |
-| `title` | ─ | Add a title line to the table. |
-| `titleize` | ─ | Titleize column headers, so `person_id` becomes `Person`. |
-| `zebra` | `false` | Turn on zebra stripes. |
+| option         | default | details                                                                                                                                                                                                                         |
+| -------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `color_scales` | ─       | Color code a column of floats, similar to the "conditional formatting" feature in Google Sheets. See [docs below](#color-scales).                                                                                               |
+| `columns`      | ─       | Manually set which columns to include. Leave unset to show all columns.                                                                                                                                                         |
+| `headers`      | ─       | Specify some or all column headers. For example, `{user_id: "Customer"}`. When unset, headers are inferred.                                                                                                                     |
+| `mark`         | ─       | `mark` is a way to highlight specific columns with a nice color. For example, use `mark: ->(row) { row[:planet] == "tatooine" }` to highlight those rows. Your lambda can also return a specific bg color or Paint color array. |
+| `row_numbers`  | `false` | Show row numbers in the table.                                                                                                                                                                                                  |
+| `search`       | ─       | String/regex to highlight in output.                                                                                                                                                                                            |
+| `separators`   | `true`  | Include column and header separators in output.                                                                                                                                                                                 |
+| `title`        | ─       | Add a title line to the table.                                                                                                                                                                                                  |
+| `titleize`     | ─       | Titleize column headers, so `person_id` becomes `Person`.                                                                                                                                                                       |
+| `zebra`        | `false` | Turn on zebra stripes.                                                                                                                                                                                                          |
 
 #### More Advanced Options
 
-| option | default | details |
-| ------ | ------- | ------- |
-| `coerce` | `true`  | if true, try to coerce strings into numbers where possible so we can format with `digits`. You may want to disable this if you already have nicely formatted ints/floats and you don't want TableTennis to mess with them. |
-| `color` | ─ | Are ANSI colors enabled? Specify `true` or `false`, or leave it as nil to autodetect. Autodetect will turn on color unless redirecting to a file. When using autodetect, you can force it on by setting `ENV["FORCE_COLOR"]`, or off with `ENV["NO_COLOR"]`. |
-| `delims` | `true` | Format ints & floats with comma delimiter, like 123,456. |
-| `digits` | `3` | Format floats to this number of digits. TableTennis will look for either `Float` cells or string floats. |
-| `layout` | `true` | This controls column widths. Leave unset or use `true` for autolayout. Autolayout will shrink the table to fit inside the terminal. `false` turns off layout and columns will be full width. Use an int to fix all columns to a certain width, or a hash to just set a few. |
-| `placeholder` | `"—"` | Put this into empty cells. |
-| `save` | ─ | If you set this to a file path, TableTennis will save your table as a CSV file too. Useful if you want to do something else with the data. |
-| `strftime` | see → | strftime string for formatting Date/Time objects. The default is `"%Y-%m-%d"`, which looks like `2025-04-21`  |
-| `theme` | ─ | When unset, will be autodetected based on terminal background color. If autodetect fails the theme defaults to :dark. You can also manually specify `:dark`, `:light` or `:ansi`. If colors are turned off this setting has no effect.|
+| option        | default | details                                                                                                                                                                                                                                                                     |
+| ------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `coerce`      | `true`  | if true, try to coerce strings into numbers where possible so we can format with `digits`. You may want to disable this if you already have nicely formatted ints/floats and you don't want TableTennis to mess with them.                                                  |
+| `color`       | ─       | Are ANSI colors enabled? Specify `true` or `false`, or leave it as nil to autodetect. Autodetect will turn on color unless redirecting to a file. When using autodetect, you can force it on by setting `ENV["FORCE_COLOR"]`, or off with `ENV["NO_COLOR"]`.                |
+| `delims`      | `true`  | Format ints & floats with comma delimiter, like 123,456.                                                                                                                                                                                                                    |
+| `digits`      | `3`     | Format floats to this number of digits. TableTennis will look for either `Float` cells or string floats.                                                                                                                                                                    |
+| `layout`      | `true`  | This controls column widths. Leave unset or use `true` for autolayout. Autolayout will shrink the table to fit inside the terminal. `false` turns off layout and columns will be full width. Use an int to fix all columns to a certain width, or a hash to just set a few. |
+| `placeholder` | `"—"`   | Put this into empty cells.                                                                                                                                                                                                                                                  |
+| `save`        | ─       | If you set this to a file path, TableTennis will save your table as a CSV file too. Useful if you want to do something else with the data.                                                                                                                                  |
+| `strftime`    | see →   | strftime string for formatting Date/Time objects. The default is `"%Y-%m-%d"`, which looks like `2025-04-21`                                                                                                                                                                |
+| `theme`       | ─       | When unset, will be autodetected based on terminal background color. If autodetect fails the theme defaults to :dark. You can also manually specify `:dark`, `:light` or `:ansi`. If colors are turned off this setting has no effect.                                      |
 
 ### Color Scales
 
@@ -120,8 +120,8 @@ puts TableTennis.new(rows, search: /hope.*empire/i })
 puts TableTennis.new(rows, row_numbers: true, zebra: true)
 ```
 
-| `:mark` | `:search` | `:row_numbers` and `:zebra` |
-| - | - | - |
+| `:mark`                             | `:search`                       | `:row_numbers` and `:zebra`                   |
+| ----------------------------------- | ------------------------------- | --------------------------------------------- |
 | ![droids](./screenshots/droids.png) | ![hope](./screenshots/hope.png) | ![row numbers](./screenshots/row_numbers.png) |
 
 ### Links
@@ -171,6 +171,10 @@ We love CSV tools and use them all the time! Here are a few that we rely on:
 - [visidata](https://www.visidata.org) - the best for poking around large files, it does everything
 
 ### Changelog
+
+#### unreleased (main)
+
+- handle data that already contains ANSI colors (@ronaldtse)
 
 #### 0.0.6 (May '25)
 

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -6,15 +6,7 @@ require "benchmark"
 require "table_tennis"
 
 #
-# internal benchmark scratch script
-#
-# TODO
-#
-# [x] line = paint(title.center(title_width), title_style || :cell)
-# [x] whitespace = columns[c].width - Util::Strings.width(value)
-# [ ] an ansi sample for tennis
-# [ ] truncate
-# [ ] tests
+# internal benchmark scratch script, ignore
 #
 
 N = 1_000_000
@@ -25,8 +17,9 @@ Benchmark.bm do |benchmark|
   benchmark.report("plain") do
     N.times { TableTennis::Util::Strings.width(PLAIN) }
   end
+
+  # GREEN is 10x slower vs PLAIN, but that's ok
   benchmark.report("painted") do
-    # GREEN is 10x slower vs PLAIN, but that's ok
     N.times { TableTennis::Util::Strings.width(GREEN) }
   end
 end

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -1,0 +1,32 @@
+#!/usr/bin/env ruby
+
+$LOAD_PATH.unshift(File.join(__dir__, "../lib"))
+
+require "benchmark"
+require "table_tennis"
+
+#
+# internal benchmark scratch script
+#
+# TODO
+#
+# [x] line = paint(title.center(title_width), title_style || :cell)
+# [x] whitespace = columns[c].width - Util::Strings.width(value)
+# [ ] an ansi sample for tennis
+# [ ] truncate
+# [ ] tests
+#
+
+N = 1_000_000
+PLAIN = "foobar"
+GREEN = "\e[38;2;0;255;0mfoobar\e[0m"
+
+Benchmark.bm do |benchmark|
+  benchmark.report("plain") do
+    N.times { TableTennis::Util::Strings.width(PLAIN) }
+  end
+  benchmark.report("painted") do
+    # GREEN is 10x slower vs PLAIN, but that's ok
+    N.times { TableTennis::Util::Strings.width(GREEN) }
+  end
+end

--- a/bin/tennis
+++ b/bin/tennis
@@ -68,6 +68,14 @@ module TableTennis
       end
     end
 
+    def colorize(str)
+      if rand < 0.5
+        Paint[str, TableTennis::Util::Colors.get("blue-400"), :black, :bold]
+      else
+        Paint[str, TableTennis::Util::Colors.get("orange-400")]
+      end
+    end
+
     FILES = %w[diamonds links numbers pigeon-racing starwars titanic]
 
     def demo
@@ -85,6 +93,16 @@ module TableTennis
       # diamonds.csv pigeon-racing.csv starwars.csv titanic.csv
       rows = CSV.read("#{ROOT}/demo/#{file}.csv", headers: true).map(&:to_h)
       rows = rows.first(options[:limit]) if options[:limit]
+
+      if options[:colorize]
+        options[:title] = colorize(options[:title]) if options[:title]
+        key = rows.first.keys.sample
+        color_key = colorize(key)
+        rows.each do |row|
+          row[color_key] = row.delete(key)
+          row.transform_values! { (rand < 0.1) ? colorize(_1) : _1 }
+        end
+      end
 
       # these can't be calculated until after the CSV is loaded
       if options[:color_scales] == ["all"]
@@ -147,6 +165,7 @@ options = {}.tap do |into|
     opts.on("--clear", "clear screen before we begin (for screenshots)")
     opts.on("--[no-]coerce", "enable/disable string coercion")
     opts.on("--[no-]color", "enable/disable ansi colors entirely")
+    opts.on("--colorize", "randomly add ANSI colors to 10% of cells")
     opts.on("--color-scales a=:b,c=:r", Hash, "color scale some column")
     opts.on("--columns STR,STR,STR", Array, "columns to include in the table")
     opts.on("--digits DIGITS", Integer, "number of digits for formatting floats")

--- a/lib/table_tennis/config.rb
+++ b/lib/table_tennis/config.rb
@@ -82,6 +82,7 @@ module TableTennis
       end
       self[:color_scales] = value
     end
+    alias_method :color_scale=, :color_scales=
 
     def placeholder=(value)
       value = "" if value.nil?

--- a/lib/table_tennis/stage/render.rb
+++ b/lib/table_tennis/stage/render.rb
@@ -81,7 +81,7 @@ module TableTennis
         style ||= :cell
 
         # add ansi codes for search
-        value = value.gsub(search) { paint(_1, :search) } if search
+        value = search_cell(value) if search
 
         # add ansi codes for links
         if config.color && (link = data.links[[r, c]])
@@ -155,6 +155,14 @@ module TableTennis
         end
       end
       memo_wise :search
+
+      # add ansi codes for search
+      def search_cell(value)
+        return value if !value.match?(search)
+        # edge case - we can't gsub a painted cell, it can mess up the escaping
+        value = Util::Strings.unpaint(value)
+        value.gsub(search) { paint(_1, :search) }
+      end
     end
   end
 end

--- a/lib/table_tennis/stage/render.rb
+++ b/lib/table_tennis/stage/render.rb
@@ -50,7 +50,7 @@ module TableTennis
         title_width = data.table_width - 4
         title = Util::Strings.truncate(config.title, title_width)
         title_style = data.get_style(r: :title) || :cell
-        line = paint(title.center(title_width), title_style || :cell)
+        line = paint(Util::Strings.center(title, title_width), title_style || :cell)
         paint("#{pipe} #{line} #{pipe}", Theme::BG)
       end
 

--- a/test/stage/test_render.rb
+++ b/test/stage/test_render.rb
@@ -153,11 +153,36 @@ module TableTennis
         end
       end
 
+      def test_search
+        rows = [{name: "Luke", planet: "Tatooine"}, {name: "Leia", planet: "Alderaan"}]
+        painted_rows = [
+          {name: Paint["Luke", :blue], planet: "Tatooine"},
+          {name: "Leia", planet: Paint["Alderaan", :red]},
+        ]
+
+        # test string search
+        output = render_string(rows:, color: true, search: "luke")
+        assert_match(/\e\[.*?m.*?Luke.*?\e\[0m/, output)
+
+        # test regex search
+        output = render_string(rows:, color: true, search: /L\w+/)
+        assert_match(/\e\[.*?m.*?Luke.*?\e\[0m/, output)
+        assert_match(/\e\[.*?m.*?Leia.*?\e\[0m/, output)
+
+        # test search with painted cells
+        output = render_string(rows: painted_rows, color: true, search: "Luke")
+        assert_match(/\e\[.*?m.*?Luke.*?\e\[0m/, output)
+
+        # test search matching painted cell content
+        output = render_string(rows: painted_rows, color: true, search: "Alderaan")
+        assert_match(/\e\[.*?m.*?Alderaan.*?\e\[0m/, output, "Alderaan should be highlighted in painted cell")
+      end
+
       protected
 
-      def create_render(color: false, rows: nil, separators: true, theme: nil, title: "xyzzy")
+      def create_render(color: false, rows: nil, separators: true, theme: nil, title: "xyzzy", search: nil)
         rows ||= [{a: "1", b: " "}]
-        config = Config.new(color:, separators:, theme:, title:)
+        config = Config.new(color:, separators:, theme:, title:, search:)
         data = TableData.new(config:, rows:)
         if data.columns.length >= 2
           data.columns[0].width = 3
@@ -166,8 +191,8 @@ module TableTennis
         Render.new(data)
       end
 
-      def render_string(color: false, rows: nil, separators: true, theme: nil, title: "xyzzy")
-        render = create_render(color:, rows:, separators:, theme:, title:)
+      def render_string(color: false, rows: nil, separators: true, theme: nil, title: "xyzzy", search: nil)
+        render = create_render(color:, rows:, separators:, theme:, title:, search:)
         render_to_string(render)
       end
 

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -23,6 +23,7 @@ module TableTennis
       # here are things that work
       assert_config_no_raise(:coerce, 0)
       assert_config_no_raise(:color, true)
+      assert_config_no_raise(:color_scale, :a)
       assert_config_no_raise(:color_scales, :a)
       assert_config_no_raise(:color_scales, {a: :b})
       assert_config_no_raise(:color_scales, %i[a b c])

--- a/test/util/test_strings.rb
+++ b/test/util/test_strings.rb
@@ -1,14 +1,30 @@
 module TableTennis
   module Util
     class TestString < Minitest::Test
+      PLAIN = "foobar"
+      GREEN = "\e[38;2;0;255;0mfoobar\e[0m"
+
+      def test_painted?
+        assert !Strings.painted?(PLAIN)
+        assert Strings.painted?(GREEN)
+      end
+
       def test_unpaint
-        assert_equal "foobar", Strings.unpaint("foo\e[123;mbar")
+        assert_equal PLAIN, Strings.unpaint(GREEN)
       end
 
       def test_width
         assert_equal 0, Strings.width("")
         assert_equal 1, Strings.width("a")
         assert_equal 4, Strings.width("🚀🚀")
+        assert_equal 6, Strings.width(PLAIN)
+        # ansi
+        assert_equal 6, Strings.width(GREEN)
+      end
+
+      def test_center
+        assert_equal " foobar ", Strings.center(PLAIN, 8)
+        assert_equal " #{GREEN} ", Strings.center(GREEN, 8)
       end
 
       def test_truncate

--- a/test/util/test_strings.rb
+++ b/test/util/test_strings.rb
@@ -54,7 +54,7 @@ module TableTennis
         assert_equal "🚀3…", Strings.truncate("🚀3🚀6", 5)
       end
 
-      def test_difficult_unicode
+      def test_truncate_difficult_unicode
         difficult = [
           "\u200f\u200e\u200e\u200f", # rtl,ltr,ltr,rtl marks
           "\u0635\u0648\u0631", # arabic sad, wah, reh
@@ -79,7 +79,7 @@ module TableTennis
         assert_equal "صور", del_rtl_ltr.call(s4)
       end
 
-      def test_grapheme_clusters
+      def test_truncate_grapheme_clusters
         hands = "👋🏻👋🏿" # \u1f44b\u1f3fb and then \u1f44b\u1f3ff
         # hardcode since this can change based on the font
         Unicode::DisplayWidth.stubs(:of).returns(2)
@@ -87,6 +87,11 @@ module TableTennis
         (1..2).each { assert_equal "…", Strings.truncate(hands, _1), "with #{_1}" }
         (3..3).each { assert_equal "👋🏻…", Strings.truncate(hands, _1), "with #{_1}" }
         (4..6).each { assert_equal "👋🏻👋🏿", Strings.truncate(hands, _1), "with #{_1}" }
+      end
+
+      def test_truncate_painted
+        assert_equal "fo…", Strings.truncate(PLAIN, 3)
+        assert_equal "\e[38;2;0;255;0mfo…\e[0m", Strings.truncate(GREEN, 3)
       end
 
       def test_titleize

--- a/test/util/test_strings.rb
+++ b/test/util/test_strings.rb
@@ -92,6 +92,33 @@ module TableTennis
       def test_truncate_painted
         assert_equal "fo…", Strings.truncate(PLAIN, 3)
         assert_equal "\e[38;2;0;255;0mfo…\e[0m", Strings.truncate(GREEN, 3)
+
+        # test that ANSI codes are properly closed when truncated
+        colored_text = Paint["hello world", :red]
+        # when truncated in the middle, preserve and close color
+        result = Strings.truncate(colored_text, 7)
+        assert_equal "\e[31mhello …\e[0m", result
+        # when not truncated, should preserve original
+        result = Strings.truncate(colored_text, 15)
+        assert_equal colored_text, result
+        # test with unclosed ANSI code
+        unclosed_text = "\e[31mhello world"
+        result = Strings.truncate(unclosed_text, 7)
+        assert_equal "\e[31mhello …\e[0m", result
+        # test with emojis and color:
+        # rocket=2, pepper=1, h=1, ellipsis=1 = 5 total
+        emoji_colored_text = Paint["🚀🌶hello", :blue]
+        result = Strings.truncate(emoji_colored_text, 5)
+        assert_equal "\e[34m🚀🌶h…\e[0m", result
+        # test shorter truncation:
+        # rocket=2, pepper=1, ellipsis=1 = 4 total
+        result = Strings.truncate(emoji_colored_text, 4)
+        assert_equal "\e[34m🚀🌶…\e[0m", result
+        # test longer emoji text with color:
+        # rocket=2, pepper=1, party=2, h=1, ellipsis=1 = 7 total
+        long_emoji_text = Paint["🚀🌶🎉hello world", :green]
+        result = Strings.truncate(long_emoji_text, 7)
+        assert_equal "\e[32m🚀🌶🎉h…\e[0m", result
       end
 
       def test_titleize


### PR DESCRIPTION
Add support for pre-existing ansi colors inside table data (title, headers and cells). Basically, we have to be a little more careful about measuring/truncating strings because they might already contain hidden ansi escape codes. Special thanks to @ronaldtse for reporting the issue and putting together the initial PR, which I used as a starting point for this work!

You can see a demo with `tennis --colorize`. The blue and orange cells came with ansi escape codes when they were passed as inputs to TableTennis:

<img width="717" height="363" alt="image" src="https://github.com/user-attachments/assets/bb4e43ab-624d-44bb-8175-5ea07d1d06d4" />
