### PR TITLE
handle nil IO.console, which can occur with Docker/CI (fixes #14, fixes #15)

### DIFF
--- a/lib/table_tennis.rb
+++ b/lib/table_tennis.rb
@@ -25,6 +25,7 @@ require "table_tennis/stage/painter"
 require "table_tennis/stage/render"
 
 require "table_tennis/util/colors"
+require "table_tennis/util/console"
 require "table_tennis/util/identify"
 require "table_tennis/util/scale"
 require "table_tennis/util/strings"

--- a/lib/table_tennis/stage/layout.rb
+++ b/lib/table_tennis/stage/layout.rb
@@ -37,7 +37,7 @@ module TableTennis
         columns.each { _1.width = _1.measure }
 
         # How much space is available, and do we already fit?
-        screen_width = IO.console.winsize[1]
+        screen_width = Util::Console.winsize[1]
         available = screen_width - chrome_width - FUDGE
         return if available >= data_width
 

--- a/lib/table_tennis/table_data.rb
+++ b/lib/table_tennis/table_data.rb
@@ -114,7 +114,7 @@ module TableTennis
     def debug(str)
       return if !config&.debug
       str = "[#{Time.now.strftime("%H:%M:%S")}] #{str}"
-      str = str.ljust(@debug_width ||= IO.console.winsize[1])
+      str = str.ljust(@debug_width ||= Util::Console.winsize[1])
       puts Paint[str, :white, :green]
     end
 

--- a/lib/table_tennis/util/console.rb
+++ b/lib/table_tennis/util/console.rb
@@ -1,0 +1,23 @@
+module TableTennis
+  module Util
+    # static wrapper around IO.console to handle the case where IO.console is nil
+    module Console
+      module_function
+
+      # supported when IO.console is nil
+      def winsize(...)
+        IO.console&.winsize(...) || [24, 80]
+      end
+
+      # not supported, don't call these
+      %i[fileno getbyte raw syswrite].each do |name|
+        define_method(name) do |*args, **kwargs, &block|
+          if !IO.console
+            raise "IO.console.#{name} not supported when IO.console is nil"
+          end
+          IO.console.send(name, *args, **kwargs, &block)
+        end
+      end
+    end
+  end
+end

--- a/test/test_table.rb
+++ b/test/test_table.rb
@@ -67,5 +67,21 @@ module TableTennis
         assert_equal([{"a" => "1"}], csv)
       end
     end
+
+    require_relative "test_helper"
+
+    # an end-to-end test when IO.console is nil, which can occur with Docker. Also see
+    # https://github.com/gurgeous/table_tennis/issues/14
+    def test_no_console
+      IO.stubs(:console).returns(nil)
+
+      # make sure we really stubbed it
+      assert_equal [10, 80], Util::Console.winsize
+      assert_raises { Util.console.raw }
+
+      # now run our two main tests
+      test_main
+      test_kitchen_sink
+    end
   end
 end


### PR DESCRIPTION
Thank you @ronaldtse for reporting this issue and suggesting a fix. Under some Docker/CI circumstances, IO.console can be nil. I have not tried this personally or dug into IO.console to discern a root cause, caveat emptor...

TableTennis is already quite cautious about accessing IO.console due to existing issues with strange ttys, Windows, zellij, etc. So the fix for this issue is pretty easy - avoid the queries if IO.console is nil. Also wrap IO.console with our own static helper to support a default winsize too.