### PR TITLE
ansi color truncation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,10 @@ jobs:
       max-parallel: 3
       matrix:
         os: [macos, ubuntu, windows]
-        ruby-version: [3.0, 3.4]
+        ruby-version: [3.0, 3.4, 4.0]
     runs-on: ${{ matrix.os }}-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: taiki-e/install-action@just
       - uses: ruby/setup-ruby@v1
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# Purpose
+
+TableTennis is a popular ruby gem for rendering ANSI-colored tables from csv-like rows (hash-ish objects). Beauty > performance, but keep small-table latency snappy.
+
+# Key flow
+
+- Public API: `TableTennis.new` -> `TableTennis::Table` (`lib/table_tennis/table.rb`).
+- Pipeline: `Format` -> `Layout` -> `Painter` -> `Render` (`lib/table_tennis/stage/*.rb`).
+- Data model: `TableData`, `Column`, `Row` (`lib/table_tennis/table_data.rb`, `lib/table_tennis/column.rb`, `lib/table_tennis/row.rb`).
+- Config/theming: `Config`, `Theme`, `Util::Colors/Console/Strings/Termbg` (`lib/table_tennis/config.rb`, `lib/table_tennis/theme.rb`, `lib/table_tennis/util/*`).
+
+# dev (prefer `just`)
+
+- `just test`
+- `just lint` / `just format`
+- `just check`
+
+# Style/conventions
+
+- Defaults and validation live in `Config` (`MagicOptions`).
+- Rendering cost is mostly in `Stage::Render` (ANSI/string work); memoization via `MemoWise` is used in hot paths.
+- Prefer short methods, short variable names, and comment lightly when code is complex
+- Ruby one-liners are find and even preferred for trivial methods

--- a/Gemfile
+++ b/Gemfile
@@ -2,12 +2,12 @@ source "https://rubygems.org"
 gemspec
 
 group :development, :test do
-  gem "amazing_print", "~> 1.7"
+  gem "amazing_print", "~> 2.0"
   gem "image_optim", "~> 0.31"
   gem "image_optim_pack", "~> 0.12"
-  gem "minitest", "~> 5.25"
+  gem "minitest", "~> 5.27"
   gem "minitest-hooks", "~> 1.5"
-  gem "mocha", "~> 2.7"
+  gem "mocha", "~> 3.0"
   gem "ostruct", "~> 0.6" # required for Ruby 3.5+
   gem "pry", "~> 0.15"
   gem "rake", "~> 13.2"

--- a/README.md
+++ b/README.md
@@ -172,6 +172,12 @@ We love CSV tools and use them all the time! Here are a few that we rely on:
 
 ### Changelog
 
+#### 1.0.0 (unreleased but soon)
+
+- better truncation with ansi colors, inspired by strings-truncation gem
+- truncation no longer supports graphemes (breaking)
+- added AGENTS.md and mise.toml
+
 #### 0.0.7 (Aug '25)
 
 - handle data that already contains ANSI colors (thx @ronaldtse, #12)

--- a/justfile
+++ b/justfile
@@ -1,3 +1,5 @@
+set quiet := true
+
 default: test
 
 # check repo - lint & test
@@ -5,8 +7,8 @@ check: lint test
 
 # for ci. don't bother linting on windows
 ci:
-  @if [[ "{{os()}}" != "windows" ]]; then just lint ; fi
-  @just test
+  if [[ "{{os()}}" != "windows" ]]; then just lint ; fi
+  just test
 
 # check test coverage
 coverage:
@@ -17,47 +19,47 @@ coverage:
 format: (lint "-a")
 
 gem-local:
-  @just banner rake install:local...
-  bundle exec rake install:local
+  just banner rake install:local...
+  @bundle exec rake install:local
 
 # this will tag, build and push to rubygems
 gem-push: check
-  @if rg -g '!justfile' "\bREMIND\b" ; then just _fatal "REMIND found, bailing" ; fi
-  @just banner rake release...
-  bundle exec rake release
+  if rg -g '!justfile' "\bREMIND\b" ; then just _fatal "REMIND found, bailing" ; fi
+  just banner rake release...
+  @bundle exec rake release
 
 # optimize images
 image_optim:
-  @# advpng/pngout are slow. consider --verbose as well
+  # advpng/pngout are slow. consider --verbose as well
   @bundle exec image_optim --allow-lossy --svgo-precision=1 --no-advpng --no-pngout -r .
 
 # lint with rubocop
 lint *ARGS:
-  @just banner lint...
-  bundle exec rubocop {{ARGS}}
+  just banner lint...
+  @bundle exec rubocop {{ARGS}}
 
 # start pry with the lib loaded
 pry:
-  bundle exec pry -I lib -r table_tennis.rb
+  @bundle exec pry -I lib -r table_tennis.rb
 
 # run tennis repeatedly
 tennis-watch *ARGS:
-  @watchexec --stop-timeout=0 --clear clear tennis {{ARGS}}
+  watchexec --stop-timeout=0 --clear clear tennis {{ARGS}}
 
 # run tests
 test *ARGS:
-  @just banner rake test {{ARGS}}
-  @bundle exec rake test {{ARGS}}
+  just banner rake test {{ARGS}}
+  bundle exec rake test {{ARGS}}
 
 # run tests repeatedly
 test-watch *ARGS:
-  watchexec --stop-timeout=0 --clear clear just test "{{ARGS}}"
+  @watchexec --stop-timeout=0 --clear clear just test "{{ARGS}}"
 
 # create sceenshot using vhs
 vhs:
-  @just banner "running vhs..."
-  vhs demo.tape
-  magick /tmp/dark.png -crop 1448x1004+18+16 screenshots/dark.png
+  just banner "running vhs..."
+  @vhs demo.tape
+  @magick /tmp/dark.png -crop 1448x1004+18+16 screenshots/dark.png
 
 #
 # util
@@ -71,6 +73,6 @@ RED      := '\e[48;2;210;015;057m'
 banner +ARGS: (_banner GREEN ARGS)
 warning +ARGS: (_banner ORANGE ARGS)
 fatal +ARGS: (_banner RED ARGS)
-  @exit 1
+  exit 1
 _banner BG +ARGS:
-  @printf '{{BOLD+TRUWHITE+BG}}[%s] %-72s {{NORMAL}}\n' "$(date +%H:%M:%S)" "{{ARGS}}"
+  printf '{{BOLD+TRUWHITE+BG}}[%s] %-72s {{NORMAL}}\n' "$(date +%H:%M:%S)" "{{ARGS}}"

--- a/justfile
+++ b/justfile
@@ -17,13 +17,13 @@ coverage:
 format: (lint "-a")
 
 gem-local:
-  @just _banner rake install:local...
+  @just banner rake install:local...
   bundle exec rake install:local
 
 # this will tag, build and push to rubygems
 gem-push: check
   @if rg -g '!justfile' "\bREMIND\b" ; then just _fatal "REMIND found, bailing" ; fi
-  @just _banner rake release...
+  @just banner rake release...
   bundle exec rake release
 
 # optimize images
@@ -33,7 +33,7 @@ image_optim:
 
 # lint with rubocop
 lint *ARGS:
-  @just _banner lint...
+  @just banner lint...
   bundle exec rubocop {{ARGS}}
 
 # start pry with the lib loaded
@@ -46,7 +46,7 @@ tennis-watch *ARGS:
 
 # run tests
 test *ARGS:
-  @just _banner rake test {{ARGS}}
+  @just banner rake test {{ARGS}}
   @bundle exec rake test {{ARGS}}
 
 # run tests repeatedly
@@ -55,7 +55,7 @@ test-watch *ARGS:
 
 # create sceenshot using vhs
 vhs:
-  @just _banner "running vhs..."
+  @just banner "running vhs..."
   vhs demo.tape
   magick /tmp/dark.png -crop 1448x1004+18+16 screenshots/dark.png
 
@@ -63,10 +63,14 @@ vhs:
 # util
 #
 
-_banner *ARGS: (_message BG_GREEN ARGS)
-_warning *ARGS: (_message BG_YELLOW ARGS)
-_fatal *ARGS: (_message BG_RED ARGS)
+TRUWHITE := '\e[38;5;231m'
+GREEN    := '\e[48;2;064;160;043m'
+ORANGE   := '\e[48;2;251;100;011m'
+RED      := '\e[48;2;210;015;057m'
+
+banner +ARGS: (_banner GREEN ARGS)
+warning +ARGS: (_banner ORANGE ARGS)
+fatal +ARGS: (_banner RED ARGS)
   @exit 1
-_message color *ARGS:
-  @msg=$(printf "[%s] %s" $(date +%H:%M:%S) "{{ARGS}}") ; \
-  printf "{{color+BOLD+WHITE}}%-72s{{ NORMAL }}\n" "$msg"
+_banner BG +ARGS:
+  @printf '{{BOLD+TRUWHITE+BG}}[%s] %-72s {{NORMAL}}\n' "$(date +%H:%M:%S)" "{{ARGS}}"

--- a/justfile
+++ b/justfile
@@ -20,27 +20,34 @@ format: (lint "-a")
 
 gem-local:
   just banner rake install:local...
-  @bundle exec rake install:local
+  bundle exec rake install:local
 
 # this will tag, build and push to rubygems
 gem-push: check
   if rg -g '!justfile' "\bREMIND\b" ; then just _fatal "REMIND found, bailing" ; fi
   just banner rake release...
-  @bundle exec rake release
+  bundle exec rake release
 
 # optimize images
 image_optim:
   # advpng/pngout are slow. consider --verbose as well
-  @bundle exec image_optim --allow-lossy --svgo-precision=1 --no-advpng --no-pngout -r .
+  bundle exec image_optim --allow-lossy --svgo-precision=1 --no-advpng --no-pngout -r .
+
+# check for outdated deps
+outdated:
+  just banner Here are the easy ones:
+  bundle outdated --filter-minor || true
+  just banner The full list:
+  bundle outdated || true
 
 # lint with rubocop
 lint *ARGS:
   just banner lint...
-  @bundle exec rubocop {{ARGS}}
+  bundle exec rubocop {{ARGS}}
 
 # start pry with the lib loaded
 pry:
-  @bundle exec pry -I lib -r table_tennis.rb
+  bundle exec pry -I lib -r table_tennis.rb
 
 # run tennis repeatedly
 tennis-watch *ARGS:
@@ -53,13 +60,13 @@ test *ARGS:
 
 # run tests repeatedly
 test-watch *ARGS:
-  @watchexec --stop-timeout=0 --clear clear just test "{{ARGS}}"
+  watchexec --stop-timeout=0 --clear clear just test "{{ARGS}}"
 
 # create sceenshot using vhs
 vhs:
   just banner "running vhs..."
-  @vhs demo.tape
-  @magick /tmp/dark.png -crop 1448x1004+18+16 screenshots/dark.png
+  vhs demo.tape
+  magick /tmp/dark.png -crop 1448x1004+18+16 screenshots/dark.png
 
 #
 # util

--- a/lib/table_tennis/util/colors.rb
+++ b/lib/table_tennis/util/colors.rb
@@ -489,6 +489,7 @@ module TableTennis
 
       # print all colors to $stdout, helps with creating themes
       def spectrum
+        # paint goes bg, fg
         max = NAMED.keys.map(&:length).max
         fmt = " %-#{max}s %s  %0.3f "
         NAMED.each do |name, color|
@@ -497,6 +498,17 @@ module TableTennis
           str2 = Paint[str, color, "black"]
           str3 = Paint["  white   ", "white", color]
           str4 = Paint[" black  ", "black", color]
+          puts "#{str1}#{str2}#{str3}#{str4}"
+        end
+
+        # with 256 - 38/5/fg or 38/5/bg
+        fmt = " ansi256 %d"
+        (1..256).each do |color|
+          str = sprintf(" ansi256 %3d ", color)
+          str1 = Paint[str, 38, 5, color, "white"]
+          str2 = Paint[str, 38, 5, color, "black"]
+          str3 = Paint["  white   ", "white", 48, 5, color]
+          str4 = Paint[" black  ", "black", 48, 5, color]
           puts "#{str1}#{str2}#{str3}#{str4}"
         end
 

--- a/lib/table_tennis/util/strings.rb
+++ b/lib/table_tennis/util/strings.rb
@@ -52,7 +52,7 @@ module TableTennis
       end
 
       ELLIPSIS = "…"
-      TRIM = /\A(\e\[[0-9;]*m|\u200B)*\z/
+      INVISIBLE = /\A(\e\[[0-9;]*m|\u200B)*\z/
 
       # Truncate a string based on the display width of characters. Does not
       # attempt to handle graphemes. Should handle emojis and international
@@ -75,21 +75,22 @@ module TableTennis
           until scan.eos?
             # are we looking at an ansi code?
             if scan.scan(ANSI_CODE)
-              painting = scan.matched != Paint::NOTHING
               buf << scan.matched
+              painting = scan.matched != Paint::NOTHING
               next
             end
 
             # what's next?
             ch = scan.getch
-            len += Unicode::DisplayWidth.of(ch)
 
-            # done?
+            # done? append one final char, possible an ELLIPSIS
+            len += Unicode::DisplayWidth.of(ch)
             if len >= stop
-              buf << (scan.check(TRIM) ? ch : ELLIPSIS)
+              buf << (scan.check(INVISIBLE) ? ch : ELLIPSIS)
               break
             end
 
+            # keep going
             buf << ch
           end
           buf << Paint::NOTHING if painting

--- a/lib/table_tennis/util/termbg.rb
+++ b/lib/table_tennis/util/termbg.rb
@@ -182,6 +182,7 @@ module TableTennis
       def load_ffi!
         module_eval do
           extend FFI::Library
+
           ffi_lib "c"
           attach_function :tcgetpgrp, %i[int], :int32
           debug("ffi attach libc.tcgetpgrp => success")

--- a/lib/table_tennis/version.rb
+++ b/lib/table_tennis/version.rb
@@ -1,3 +1,3 @@
 module TableTennis
-  VERSION = "0.0.7"
+  VERSION = "1.0.0"
 end

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,8 @@
+[env]
+_.path = ['{{config_root}}/bin']
+
+[hooks]
+postinstall = ['bundle']
+
+[tools]
+ruby = "3.4.2"

--- a/table_tennis.gemspec
+++ b/table_tennis.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   # gem dependencies
   s.add_dependency "csv", "~> 3.3" # required for Ruby 3.4+
   s.add_dependency "ffi", "~> 1.17" # required for Ruby 3.2+
-  s.add_dependency "memo_wise", "~> 1.11"
+  s.add_dependency "memo_wise", "~> 1.13"
   s.add_dependency "paint", "~> 2.3"
-  s.add_dependency "unicode-display_width", "~> 3.1"
+  s.add_dependency "unicode-display_width", "~> 3.2"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -52,7 +52,7 @@ class Minitest::Test
   def ab = [{a: 1, b: 2}]
 
   def reset_memo_wise!
-    @memoized ||= ObjectSpace.each_object(Module).select { _1.included_modules.include? MemoWise }
+    @memoized ||= ObjectSpace.each_object(Module).select { _1.included_modules.include? MemoWise } # rubocop:disable Style/ModuleMemberExistenceCheck
     @memoized.each do
       _1.reset_memo_wise if _1.instance_variable_defined?(:@_memo_wise)
     end

--- a/test/util/test_strings.rb
+++ b/test/util/test_strings.rb
@@ -36,12 +36,12 @@ module TableTennis
           "", "abc", "café", zed, "🌶", "🚀",
           # display width is 5
           "abcde",
-          "1#{zed}2345#{zed}",
+          "1#{zed}2345",
           "1🌶345",
           "1🚀45",
           "1🚀🚀",
         ].each do
-          assert_equal _1, Strings.truncate(_1, 5)
+          assert_equal _1, Strings.truncate(_1, 5), "failed with #{_1.chars.inspect}"
         end
 
         # display width > 5
@@ -54,40 +54,53 @@ module TableTennis
         assert_equal "🚀3…", Strings.truncate("🚀3🚀6", 5)
       end
 
-      def test_truncate_difficult_unicode
-        difficult = [
-          "\u200f\u200e\u200e\u200f", # rtl,ltr,ltr,rtl marks
-          "\u0635\u0648\u0631", # arabic sad, wah, reh
-        ].join
+      def test_truncate_ansi
+        reset = "\e[0m"
+        red = "\e[48;2;210;150;057m"
+        gre = "\e[48;2;064;160;043m"
 
-        s1 = Strings.truncate(difficult, 1)
-        s2 = Strings.truncate(difficult, 2)
-        s3 = Strings.truncate(difficult, 3)
-        s4 = Strings.truncate(difficult, 4)
-
-        assert_equal 5, s1.length
-        assert_equal 6, s2.length
-        assert_equal 7, s3.length
-        assert_equal 7, s4.length
-
-        # uprint = ->(str) { str.chars.map { "\\u#{_1.ord.to_s(16)}" }.join.gsub("\\u2026", "…") }
-        # strip rtl/ltr marks for easy comparison here
-        del_rtl_ltr = ->(str) { str.gsub(/[\u200e-\u200f]/, "") }
-        assert_equal "…", del_rtl_ltr.call(s1)
-        assert_equal "ص…", del_rtl_ltr.call(s2)
-        assert_equal "صور", del_rtl_ltr.call(s3)
-        assert_equal "صور", del_rtl_ltr.call(s4)
+        # long strings come through verbatim
+        str = "#{red}12#{gre}3456789#{reset}"
+        assert_equal str, Strings.truncate(str, 999)
+        assert_equal "#{red}12#{gre}34…#{reset}", Strings.truncate(str, 5)
       end
 
-      def test_truncate_grapheme_clusters
-        hands = "👋🏻👋🏿" # \u1f44b\u1f3fb and then \u1f44b\u1f3ff
-        # hardcode since this can change based on the font
-        Unicode::DisplayWidth.stubs(:of).returns(2)
+      # removed buggy support for difficult unicode in 1.0
+      # def test_truncate_difficult_unicode
+      #   difficult = [
+      #     "\u200f\u200e\u200e\u200f", # rtl,ltr,ltr,rtl marks
+      #     "\u0635\u0648\u0631", # arabic sad, wah, reh
+      #   ].join
 
-        (1..2).each { assert_equal "…", Strings.truncate(hands, _1), "with #{_1}" }
-        (3..3).each { assert_equal "👋🏻…", Strings.truncate(hands, _1), "with #{_1}" }
-        (4..6).each { assert_equal "👋🏻👋🏿", Strings.truncate(hands, _1), "with #{_1}" }
-      end
+      #   s1 = Strings.truncate(difficult, 1)
+      #   s2 = Strings.truncate(difficult, 2)
+      #   s3 = Strings.truncate(difficult, 3)
+      #   s4 = Strings.truncate(difficult, 4)
+
+      #   assert_equal 5, s1.length
+      #   assert_equal 6, s2.length
+      #   assert_equal 7, s3.length
+      #   assert_equal 7, s4.length
+
+      #   # uprint = ->(str) { str.chars.map { "\\u#{_1.ord.to_s(16)}" }.join.gsub("\\u2026", "…") }
+      #   # strip rtl/ltr marks for easy comparison here
+      #   del_rtl_ltr = ->(str) { str.gsub(/[\u200e-\u200f]/, "") }
+      #   assert_equal "…", del_rtl_ltr.call(s1)
+      #   assert_equal "ص…", del_rtl_ltr.call(s2)
+      #   assert_equal "صور", del_rtl_ltr.call(s3)
+      #   assert_equal "صور", del_rtl_ltr.call(s4)
+      # end
+
+      # removed buggy support for difficult unicode in 1.0
+      # def test_truncate_grapheme_clusters
+      #   hands = "👋🏻👋🏿" # \u1f44b\u1f3fb and then \u1f44b\u1f3ff
+      #   # hardcode since this can change based on the font
+      #   Unicode::DisplayWidth.stubs(:of).returns(2)
+
+      #   (1..2).each { assert_equal "…", Strings.truncate(hands, _1), "with #{_1}" }
+      #   (3..3).each { assert_equal "👋🏻…", Strings.truncate(hands, _1), "with #{_1}" }
+      #   (4..6).each { assert_equal "👋🏻👋🏿", Strings.truncate(hands, _1), "with #{_1}" }
+      # end
 
       def test_truncate_painted
         assert_equal "fo…", Strings.truncate(PLAIN, 3)

--- a/test/util/test_strings.rb
+++ b/test/util/test_strings.rb
@@ -2,15 +2,15 @@ module TableTennis
   module Util
     class TestString < Minitest::Test
       PLAIN = "foobar"
-      GREEN = "\e[38;2;0;255;0mfoobar\e[0m"
+      GREEN_STR = "\e[38;2;0;255;0mfoobar\e[0m"
 
       def test_painted?
         assert !Strings.painted?(PLAIN)
-        assert Strings.painted?(GREEN)
+        assert Strings.painted?(GREEN_STR)
       end
 
       def test_unpaint
-        assert_equal PLAIN, Strings.unpaint(GREEN)
+        assert_equal PLAIN, Strings.unpaint(GREEN_STR)
       end
 
       def test_width
@@ -19,12 +19,12 @@ module TableTennis
         assert_equal 4, Strings.width("🚀🚀")
         assert_equal 6, Strings.width(PLAIN)
         # ansi
-        assert_equal 6, Strings.width(GREEN)
+        assert_equal 6, Strings.width(GREEN_STR)
       end
 
       def test_center
         assert_equal " foobar ", Strings.center(PLAIN, 8)
-        assert_equal " #{GREEN} ", Strings.center(GREEN, 8)
+        assert_equal " #{GREEN_STR} ", Strings.center(GREEN_STR, 8)
       end
 
       def test_truncate
@@ -54,57 +54,29 @@ module TableTennis
         assert_equal "🚀3…", Strings.truncate("🚀3🚀6", 5)
       end
 
+      Z = "\e[0m"
+      R = "\e[48;2;210;150;057m" # turn on red
+      G = "\e[48;2;064;160;043m" # turn on green
+
       def test_truncate_ansi
-        reset = "\e[0m"
-        red = "\e[48;2;210;150;057m"
-        gre = "\e[48;2;064;160;043m"
-
-        # long strings come through verbatim
-        str = "#{red}12#{gre}3456789#{reset}"
-        assert_equal str, Strings.truncate(str, 999)
-        assert_equal "#{red}12#{gre}34…#{reset}", Strings.truncate(str, 5)
+        [
+          # input, width, exp
+          ["#{R}12#{G}3456789#{Z}", 5, "#{R}12#{G}34…#{Z}"],
+          ["#{R}12#{G}3456789#{Z}", 8, "#{R}12#{G}34567…#{Z}"],
+          ["#{R}12#{G}3456789#{Z}", 9, "#{R}12#{G}3456789#{Z}"],
+          ["#{R}12#{G}3456789#{Z}", 10, "#{R}12#{G}3456789#{Z}"],
+          ["#{R}1234#{Z}", 3, "#{R}12…#{Z}"],
+          ["#{R}12#{G}34#{Z}", 4, "#{R}12#{G}34#{Z}"],
+          ["#{R}12#{Z}3456", 4, "#{R}12#{Z}3…"],
+        ].each do |input, stop, exp|
+          output = Strings.truncate(input, stop)
+          assert_equal exp, output, "failed with #{input.inspect} @ #{stop}"
+        end
       end
-
-      # removed buggy support for difficult unicode in 1.0
-      # def test_truncate_difficult_unicode
-      #   difficult = [
-      #     "\u200f\u200e\u200e\u200f", # rtl,ltr,ltr,rtl marks
-      #     "\u0635\u0648\u0631", # arabic sad, wah, reh
-      #   ].join
-
-      #   s1 = Strings.truncate(difficult, 1)
-      #   s2 = Strings.truncate(difficult, 2)
-      #   s3 = Strings.truncate(difficult, 3)
-      #   s4 = Strings.truncate(difficult, 4)
-
-      #   assert_equal 5, s1.length
-      #   assert_equal 6, s2.length
-      #   assert_equal 7, s3.length
-      #   assert_equal 7, s4.length
-
-      #   # uprint = ->(str) { str.chars.map { "\\u#{_1.ord.to_s(16)}" }.join.gsub("\\u2026", "…") }
-      #   # strip rtl/ltr marks for easy comparison here
-      #   del_rtl_ltr = ->(str) { str.gsub(/[\u200e-\u200f]/, "") }
-      #   assert_equal "…", del_rtl_ltr.call(s1)
-      #   assert_equal "ص…", del_rtl_ltr.call(s2)
-      #   assert_equal "صور", del_rtl_ltr.call(s3)
-      #   assert_equal "صور", del_rtl_ltr.call(s4)
-      # end
-
-      # removed buggy support for difficult unicode in 1.0
-      # def test_truncate_grapheme_clusters
-      #   hands = "👋🏻👋🏿" # \u1f44b\u1f3fb and then \u1f44b\u1f3ff
-      #   # hardcode since this can change based on the font
-      #   Unicode::DisplayWidth.stubs(:of).returns(2)
-
-      #   (1..2).each { assert_equal "…", Strings.truncate(hands, _1), "with #{_1}" }
-      #   (3..3).each { assert_equal "👋🏻…", Strings.truncate(hands, _1), "with #{_1}" }
-      #   (4..6).each { assert_equal "👋🏻👋🏿", Strings.truncate(hands, _1), "with #{_1}" }
-      # end
 
       def test_truncate_painted
         assert_equal "fo…", Strings.truncate(PLAIN, 3)
-        assert_equal "\e[38;2;0;255;0mfo…\e[0m", Strings.truncate(GREEN, 3)
+        assert_equal "\e[38;2;0;255;0mfo…\e[0m", Strings.truncate(GREEN_STR, 3)
 
         # test that ANSI codes are properly closed when truncated
         colored_text = Paint["hello world", :red]
@@ -146,6 +118,42 @@ module TableTennis
           assert_equal exp, Strings.titleize(str)
         end
       end
+
+      # removed buggy support for difficult unicode (in 1.0)
+      # def test_truncate_difficult_unicode
+      #   difficult = [
+      #     "\u200f\u200e\u200e\u200f", # rtl,ltr,ltr,rtl marks
+      #     "\u0635\u0648\u0631", # arabic sad, wah, reh
+      #   ].join
+      #
+      #   s1 = Strings.truncate(difficult, 1)
+      #   s2 = Strings.truncate(difficult, 2)
+      #   s3 = Strings.truncate(difficult, 3)
+      #   s4 = Strings.truncate(difficult, 4)
+      #
+      #   assert_equal 5, s1.length
+      #   assert_equal 6, s2.length
+      #   assert_equal 7, s3.length
+      #   assert_equal 7, s4.length
+      #
+      #   # uprint = ->(str) { str.chars.map { "\\u#{_1.ord.to_s(16)}" }.join.gsub("\\u2026", "…") }
+      #   # strip rtl/ltr marks for easy comparison here
+      #   del_rtl_ltr = ->(str) { str.gsub(/[\u200e-\u200f]/, "") }
+      #   assert_equal "…", del_rtl_ltr.call(s1)
+      #   assert_equal "ص…", del_rtl_ltr.call(s2)
+      #   assert_equal "صور", del_rtl_ltr.call(s3)
+      #   assert_equal "صور", del_rtl_ltr.call(s4)
+      # end
+      #
+      # def test_truncate_grapheme_clusters
+      #   hands = "👋🏻👋🏿" # \u1f44b\u1f3fb and then \u1f44b\u1f3ff
+      #   # hardcode since this can change based on the font
+      #   Unicode::DisplayWidth.stubs(:of).returns(2)
+
+      #   (1..2).each { assert_equal "…", Strings.truncate(hands, _1), "with #{_1}" }
+      #   (3..3).each { assert_equal "👋🏻…", Strings.truncate(hands, _1), "with #{_1}" }
+      #   (4..6).each { assert_equal "👋🏻👋🏿", Strings.truncate(hands, _1), "with #{_1}" }
+      # end
     end
   end
 end


### PR DESCRIPTION
Better support for truncating cells that contain ansi colors. I removed the (buggy) code that handled really complicated unicode cases, including keeping graghemes together. Not sure anyone was using that, but this is a breaking change so it won't be released until v1.

Also updated deps.